### PR TITLE
Simplify set interfaces with type embedding

### DIFF
--- a/containers/sets/sets.go
+++ b/containers/sets/sets.go
@@ -38,16 +38,14 @@ type Set interface {
 	ToStringSlice() []string
 }
 
-type set struct {
-	underlying map[interface{}]struct{}
-}
+type set map[interface{}]struct{}
 
 var present = struct{}{} // 0 bytes
 
 // NewSet creates a new set. The initial capacity does not bound the set's size:
 // sets grow to accommodate the number of elements to store.
 func NewSet(initialCapacity int) Set {
-	return &set{underlying: make(map[interface{}]struct{}, initialCapacity)}
+	return make(set, initialCapacity)
 }
 
 // NewSetFromStrings creates a new set from the specified strings.
@@ -59,34 +57,34 @@ func NewSetFromStrings(strings ...string) Set {
 	return set
 }
 
-func (s *set) Add(element interface{}) {
-	s.underlying[element] = present
+func (s set) Add(element interface{}) {
+	s[element] = present
 }
 
-func (s *set) Contains(element interface{}) bool {
-	_, found := s.underlying[element]
+func (s set) Contains(element interface{}) bool {
+	_, found := s[element]
 	return found
 }
 
-func (s *set) Remove(element interface{}) {
-	delete(s.underlying, element)
+func (s set) Remove(element interface{}) {
+	delete(s, element)
 }
 
-func (s *set) Size() int {
-	return len(s.underlying)
+func (s set) Size() int {
+	return len(s)
 }
 
-func (s *set) ToSlice() []interface{} {
+func (s set) ToSlice() []interface{} {
 	slice := make([]interface{}, 0, s.Size())
-	for element := range s.underlying {
+	for element := range s {
 		slice = append(slice, element)
 	}
 	return slice
 }
 
-func (s *set) ToStringSlice() []string {
+func (s set) ToStringSlice() []string {
 	slice := make([]string, 0, s.Size())
-	for element := range s.underlying {
+	for element := range s {
 		slice = append(slice, element.(string)) // TODO (Geish): check type and call fmt.Sprint if not a string?
 	}
 	return slice

--- a/containers/sets/thread_safe_expirable.go
+++ b/containers/sets/thread_safe_expirable.go
@@ -6,8 +6,8 @@ import (
 )
 
 type threadSafeExpirableSet struct {
-	mutex      sync.RWMutex
-	underlying Set
+	sync.RWMutex
+	Set
 }
 
 // NewThreadSafeExpirableSet creates a new thread-safe set using a read-write
@@ -16,41 +16,41 @@ type threadSafeExpirableSet struct {
 // the number of elements to store.
 // TTL (time to live) specifies the duration after which an element expires.
 func NewThreadSafeExpirableSet(initialCapacity int, ttl time.Duration) Set {
-	return &threadSafeExpirableSet{underlying: NewExpirableSet(initialCapacity, ttl)}
+	return &threadSafeExpirableSet{Set: NewExpirableSet(initialCapacity, ttl)}
 }
 
 func (s *threadSafeExpirableSet) Add(element interface{}) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.underlying.Add(element)
+	s.Lock()
+	defer s.Unlock()
+	s.Add(element)
 }
 
 func (s *threadSafeExpirableSet) Contains(element interface{}) bool {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.underlying.Contains(element)
+	s.RLock()
+	defer s.RUnlock()
+	return s.Contains(element)
 }
 
 func (s *threadSafeExpirableSet) Remove(element interface{}) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.underlying.Remove(element)
+	s.Lock()
+	defer s.Unlock()
+	s.Remove(element)
 }
 
 func (s *threadSafeExpirableSet) Size() int {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.underlying.Size()
+	s.RLock()
+	defer s.RUnlock()
+	return s.Size()
 }
 
 func (s *threadSafeExpirableSet) ToSlice() []interface{} {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.underlying.ToSlice()
+	s.RLock()
+	defer s.RUnlock()
+	return s.ToSlice()
 }
 
 func (s *threadSafeExpirableSet) ToStringSlice() []string {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.underlying.ToStringSlice()
+	s.RLock()
+	defer s.RUnlock()
+	return s.ToStringSlice()
 }

--- a/containers/sets/thread_safe_expirable.go
+++ b/containers/sets/thread_safe_expirable.go
@@ -6,7 +6,7 @@ import (
 )
 
 type threadSafeExpirableSet struct {
-	sync.RWMutex
+	mutex sync.RWMutex
 	Set
 }
 
@@ -20,37 +20,37 @@ func NewThreadSafeExpirableSet(initialCapacity int, ttl time.Duration) Set {
 }
 
 func (s *threadSafeExpirableSet) Add(element interface{}) {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.Add(element)
 }
 
 func (s *threadSafeExpirableSet) Contains(element interface{}) bool {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.Contains(element)
 }
 
 func (s *threadSafeExpirableSet) Remove(element interface{}) {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.Remove(element)
 }
 
 func (s *threadSafeExpirableSet) Size() int {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.Size()
 }
 
 func (s *threadSafeExpirableSet) ToSlice() []interface{} {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.ToSlice()
 }
 
 func (s *threadSafeExpirableSet) ToStringSlice() []string {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.ToStringSlice()
 }


### PR DESCRIPTION
As a suggestion instead of using **underlying** variables, why not use type embedding directly in structs and simplify the API's?